### PR TITLE
Transfer to governance module account instead of burning

### DIFF
--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -141,7 +141,7 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
 					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
 					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
-					sdk.NewAttribute(types.AttributeKeyBurnedCoins, coinsBurned.String()),
+					sdk.NewAttribute(types.AttributeKeySlashedCoins, coinsBurned.String()),
 				),
 			)
 			k.sk.Jail(sdkCtx, consAddr)

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -103,7 +103,7 @@ func (k Keeper) SlashWithInfractionReason(ctx context.Context, consAddr sdk.Cons
 			sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
 			reasonAttr,
-			sdk.NewAttribute(types.AttributeKeyBurnedCoins, coinsBurned.String()),
+			sdk.NewAttribute(types.AttributeKeySlashedCoins, coinsBurned.String()),
 		),
 	)
 	return nil

--- a/x/slashing/types/events.go
+++ b/x/slashing/types/events.go
@@ -11,7 +11,7 @@ const (
 	AttributeKeyReason       = "reason"
 	AttributeKeyJailed       = "jailed"
 	AttributeKeyMissedBlocks = "missed_blocks"
-	AttributeKeyBurnedCoins  = "burned_coins"
+	AttributeKeySlashedCoins = "slashed_coins"
 
 	AttributeValueUnspecified      = "unspecified"
 	AttributeValueDoubleSign       = "double_sign"

--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cosmossdk.io/math"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -55,7 +56,7 @@ func (k Keeper) burnBondedTokens(ctx context.Context, amt math.Int) error {
 
 	coins := sdk.NewCoins(sdk.NewCoin(bondDenom, amt))
 
-	return k.bankKeeper.BurnCoins(ctx, types.BondedPoolName, coins)
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.BondedPoolName, govtypes.ModuleName, coins)
 }
 
 // burnNotBondedTokens burns coins from the not bonded pool module account
@@ -72,7 +73,7 @@ func (k Keeper) burnNotBondedTokens(ctx context.Context, amt math.Int) error {
 
 	coins := sdk.NewCoins(sdk.NewCoin(bondDenom, amt))
 
-	return k.bankKeeper.BurnCoins(ctx, types.NotBondedPoolName, coins)
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.NotBondedPoolName, govtypes.ModuleName, coins)
 }
 
 // TotalBondedTokens total staking tokens supply which is bonded

--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -42,7 +42,8 @@ func (k Keeper) notBondedTokensToBonded(ctx context.Context, tokens math.Int) er
 	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.NotBondedPoolName, types.BondedPoolName, coins)
 }
 
-// burnBondedTokens burns coins from the bonded pool module account
+// burnBondedTokens transfers coins from the bonded pool module account to the governance module account.
+// This is to avoid burning tokens and instead make them controllable by governance.
 func (k Keeper) burnBondedTokens(ctx context.Context, amt math.Int) error {
 	if !amt.IsPositive() {
 		// skip as no coins need to be burned
@@ -59,7 +60,8 @@ func (k Keeper) burnBondedTokens(ctx context.Context, amt math.Int) error {
 	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.BondedPoolName, govtypes.ModuleName, coins)
 }
 
-// burnNotBondedTokens burns coins from the not bonded pool module account
+// burnNotBondedTokens transfers coins from the not bonded pool module account to the governance module account.
+// This is to avoid burning tokens and instead make them controllable by governance.
 func (k Keeper) burnNotBondedTokens(ctx context.Context, amt math.Int) error {
 	if !amt.IsPositive() {
 		// skip as no coins need to be burned


### PR DESCRIPTION
# Description

Related to https://github.com/fuel-infrastructure/fuel-sequencer/issues/431

Burning happens at:

- Staking module upon slashing
- Governance module, if configured to do so

Since burning at the governance module can be bypassed via the module's parameters, the burning logic was not changed in this case.